### PR TITLE
Standing Update and Selected Car

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
         "reduxjs",
         "shadcn",
         "signalr",
+        "tinycolor",
         "trackmap"
     ],
     "eslint.format.enable": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "dbaeumer",
         "endregion",
         "Laptime",
+        "loginexternal",
         "Multiclass",
         "pitbox",
         "Pitwall",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "set-interval-async": "^3.0.3",
         "tailwind-merge": "^2.2.0",
         "tailwindcss-animate": "^1.0.7",
+        "tinycolor2": "^1.6.0",
         "use-debounce": "^10.0.0",
         "vaul": "^0.8.0",
         "zod": "^3.22.4"
@@ -54,6 +55,7 @@
         "@types/react-dom": "^18",
         "@types/react-grid-layout": "^1.3.5",
         "@types/signalr": "^2.4.3",
+        "@types/tinycolor2": "^1.4.6",
         "autoprefixer": "^10.0.1",
         "eslint": "^8",
         "eslint-config-next": "14.0.4",
@@ -2097,6 +2099,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
       "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
+      "dev": true
+    },
+    "node_modules/@types/tinycolor2": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
+      "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
       "dev": true
     },
     "node_modules/@types/use-sync-external-store": {
@@ -6294,6 +6302,11 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "set-interval-async": "^3.0.3",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
+    "tinycolor2": "^1.6.0",
     "use-debounce": "^10.0.0",
     "vaul": "^0.8.0",
     "zod": "^3.22.4"
@@ -58,6 +59,7 @@
     "@types/react-dom": "^18",
     "@types/react-grid-layout": "^1.3.5",
     "@types/signalr": "^2.4.3",
+    "@types/tinycolor2": "^1.4.6",
     "autoprefixer": "^10.0.1",
     "eslint": "^8",
     "eslint-config-next": "14.0.4",

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -135,7 +135,7 @@ export default function Login() {
         } else if (displayRegister && oAuthProviderData != null) {
             return <Register accountFormValues={{ email: oAuthProviderData.email, name: oAuthProviderData.name, provider: oAuthProviderData.provider, token: oAuthProviderData.token, iracingCustomerId: '' }} />
         } else if (displayReturnToApp) {
-            return <Alert variant="default" color="success">Authentication sucessful, please return to the app.</Alert>
+            return <Alert variant="default" color="success">Authentication successful, please return to the app.</Alert>
         } else {
             return <RenderLogin />
         }

--- a/src/app/pitwall/dashboard/[id]/page.tsx
+++ b/src/app/pitwall/dashboard/[id]/page.tsx
@@ -29,7 +29,7 @@ export default function Page({ params }: { params: { id: string } }) {
                             <TrackMap />
                         </DashboardCard>
                     </div>
-                    <div key="standings" className="overflow-hidden" data-grid={{ x: 3, y: 0, w: 5, h: 3, minH: 2 }}>
+                    <div key="standings" className="overflow-hidden" data-grid={{ x: 3, y: 0, w: 9, h: 7, minH: 2 }}>
                         <DashboardCard title='Standings'>
                             <Standings />
                         </DashboardCard>

--- a/src/components/core/main-nav.tsx
+++ b/src/components/core/main-nav.tsx
@@ -7,9 +7,17 @@ import { usePathname } from "next/navigation"
 import { siteConfig } from "@/config/site"
 import { cn } from "@/lib/utils"
 import { Icons } from "@/components/core/icons"
+import {
+  selectUser,
+  useSelector,
+} from '@/lib/redux'
+import { User } from "@/lib/redux/slices/authSlice/models";
 
 export function MainNav({ isPublic }: { isPublic: boolean }) {
   const pathname = usePathname()
+
+  const user = useSelector<User>(selectUser)
+  const dashboardHref = "/pitwall/dashboard/" + user.pitBoxSessionId
 
   return (
     <div className="mr-4 hidden md:flex">
@@ -22,13 +30,13 @@ export function MainNav({ isPublic }: { isPublic: boolean }) {
       {!isPublic &&
         <nav className="flex items-center space-x-6 text-sm font-medium">
           <Link
-            href="/docs"
+            href={dashboardHref}
             className={cn(
               "transition-colors hover:text-foreground/80",
-              pathname === "/docs" ? "text-foreground" : "text-foreground/60"
+              pathname?.startsWith("/pitwall/dashboard") ? "text-foreground" : "text-foreground/60",
             )}
           >
-            Dashboards
+            Dashboard
           </Link>
           <Link
             href="/docs/components"

--- a/src/components/standings/standings.tsx
+++ b/src/components/standings/standings.tsx
@@ -3,9 +3,9 @@ import {
     useSelector,
     selectLiveTiming,
     LiveTiming,
-    selectedCarNumber,
     standingsSlice,
     useDispatch,
+    selectCurrentSession,
 } from '@/lib/redux'
 import { useMemo, useState, useEffect } from 'react';
 import {
@@ -13,10 +13,12 @@ import {
     useMaterialReactTable,
     type MRT_ColumnDef,
     MRT_RowSelectionState,
+    MRT_Row,
 } from 'material-react-table';
 
 import { createTheme, ThemeProvider, useTheme } from '@mui/material';
 import { convertMsToDisplay } from '../utils/formatter/UnitConversion';
+import tinycolor from 'tinycolor2';
 
 
 export const Standings = () => {
@@ -25,6 +27,7 @@ export const Standings = () => {
     const [data, setData] = useState<LiveTiming[]>([]);
     const standingsData = useSelector<LiveTiming[]>(selectLiveTiming)
     const [rowSelection, setRowSelection] = useState<MRT_RowSelectionState>({});
+    const session = useSelector(selectCurrentSession)
 
     useEffect(() => {
         setData(standingsData)
@@ -159,6 +162,21 @@ export const Standings = () => {
         dispatch(standingsSlice.actions.updateSelectedCar(value));
     }, [dispatch, rowSelection]);
 
+  // Set the background color of the rows to the multiclass color, when in a multiclass race
+  const getRowSx = (row: MRT_Row<LiveTiming>) => {
+    const classColor = tinycolor(row.original.classColor);
+    classColor.setAlpha(0.1);
+
+    const backgroundColorStyle = session?.isMulticlass ? { backgroundColor: classColor.toHex8String() } : {};
+
+    const res = {
+    cursor: "pointer",
+    ...backgroundColorStyle
+    };
+
+    return res;
+  };
+
     const table = useMaterialReactTable({
         columns,
         data, //data must be memoized or stable (useState, useMemo, defined outside of this component, etc.)
@@ -201,7 +219,7 @@ export const Standings = () => {
         positionToolbarAlertBanner: 'none',
         muiTableBodyRowProps: ({ row }) => ({
             onClick: row.getToggleSelectedHandler(),
-            sx: { cursor: 'pointer' },
+            sx: getRowSx(row),
         }),
     });
     return (

--- a/src/components/standings/standings.tsx
+++ b/src/components/standings/standings.tsx
@@ -1,23 +1,30 @@
 'use client'
-import { StatusOnlineIcon } from "@heroicons/react/outline";
 import {
     useSelector,
     selectLiveTiming,
     LiveTiming,
+    selectedCarNumber,
+    standingsSlice,
+    useDispatch,
 } from '@/lib/redux'
 import { useMemo, useState, useEffect } from 'react';
 import {
     MaterialReactTable,
     useMaterialReactTable,
     type MRT_ColumnDef,
+    MRT_RowSelectionState,
 } from 'material-react-table';
 
 import { createTheme, ThemeProvider, useTheme } from '@mui/material';
+import { convertMsToDisplay } from '../utils/formatter/UnitConversion';
 
 
 export const Standings = () => {
+    const dispatch = useDispatch()
+
     const [data, setData] = useState<LiveTiming[]>([]);
     const standingsData = useSelector<LiveTiming[]>(selectLiveTiming)
+    const [rowSelection, setRowSelection] = useState<MRT_RowSelectionState>({});
 
     useEffect(() => {
         setData(standingsData)
@@ -40,43 +47,50 @@ export const Standings = () => {
         () => [
             {
                 accessorKey: "position",
-                header: 'Position',
-                size: 1
+                header: 'Pos.',
+                size: 70,
+                enableColumnOrdering: false,
             },
             {
                 accessorKey: 'classPosition',
                 header: 'classPosition',
-                size: 150,
+                size: 1,
             },
             {
                 accessorKey: 'carNumber',
-                header: 'carNumber',
-                size: 150,
+                header: 'Car #',
+                size: 80,
+                enableColumnOrdering: false,
             },
             {
                 accessorKey: 'driverName',
-                header: 'driverName',
+                header: 'Driver Name',
                 size: 150,
             },
             {
                 accessorKey: 'leaderDelta',
-                header: 'leaderDelta',
-                size: 150,
+                header: 'Gap',
+                size: 100,
+                enableSorting: false,
             },
             {
                 accessorKey: 'nextCarDelta',
-                header: 'nextCarDelta',
-                size: 150,
+                header: 'Int',
+                size: 100,
+                enableSorting: false,
             },
             {
                 accessorKey: 'lastLaptime',
-                header: 'lastLaptime',
+                header: 'Last Laptime',
                 size: 150,
+                Cell: ({ cell }) => convertMsToDisplay(cell.getValue())
             },
             {
                 accessorKey: 'bestLaptime',
-                header: 'bestLaptime',
+                header: 'Best Laptime',
                 size: 150,
+                Cell: ({ cell }) => convertMsToDisplay(cell.getValue())
+
             },
             {
                 accessorKey: 'teamName',
@@ -85,18 +99,24 @@ export const Standings = () => {
             },
             {
                 accessorKey: 'lap',
-                header: 'lap',
-                size: 150,
+                header: 'Lap #',
+                size: 60,
+                enableColumnOrdering: false,
+                enableSorting: false,
             },
             {
                 accessorKey: 'pitStopCount',
-                header: 'pitStopCount',
-                size: 150,
+                header: 'Pit Stop #',
+                size: 85,
+                enableColumnOrdering: false,
+                enableSorting: false,
             },
             {
                 accessorKey: 'stintLapCount',
-                header: 'stintLapCount',
-                size: 150,
+                header: 'Stint Laps',
+                size: 99,
+                enableColumnOrdering: false,
+                enableSorting: false,
             },
             {
                 accessorKey: 'standingPosition', //normal accessorKey
@@ -132,6 +152,12 @@ export const Standings = () => {
         [],
     );
 
+    // Store the selected car in the state so that we can show it in other components
+    useEffect(() => {
+        const keys = Object.keys(rowSelection)
+        const value = keys !== undefined ? keys[0] : undefined
+        dispatch(standingsSlice.actions.updateSelectedCar(value));
+    }, [dispatch, rowSelection]);
 
     const table = useMaterialReactTable({
         columns,
@@ -148,9 +174,9 @@ export const Standings = () => {
                 'safetyRating': false,
                 'driverShortName': false,
                 'teamName': false,
-                'lap': false,
-                'pitStopCount': false,
-                'stintLapCount': false
+                'lap': true,
+                'pitStopCount': true,
+                'stintLapCount': true
             },
             sorting: [
                 {
@@ -159,13 +185,17 @@ export const Standings = () => {
                 }
             ],
         },
+        getRowId: (row) => row.carNumber,
         enableColumnOrdering: true,
         enableColumnActions: false,
         enableColumnFilters: false,
+        enableColumnResizing: true,
         enablePagination: false,
         enableSorting: true,
         enableRowSelection: true,
         enableMultiRowSelection: false,
+        onRowSelectionChange: setRowSelection,
+        state: { rowSelection},
         enableFullScreenToggle: false,
         enableDensityToggle: false,
         positionToolbarAlertBanner: 'none',

--- a/src/components/trackmap/trackmap.tsx
+++ b/src/components/trackmap/trackmap.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { LiveTiming, selectLiveTiming, selectCurrentTrack, useSelector } from '@/lib/redux';
+import { LiveTiming, selectLiveTiming, selectCurrentTrack, useSelector, selectedCarNumber } from '@/lib/redux';
 import Script from 'next/script';
 import React, { useRef, useState, useEffect, useCallback } from 'react'
 import { useDebounce } from 'use-debounce';
@@ -15,6 +15,7 @@ export const TrackMap = () => {
     const track = useSelector(selectCurrentTrack)
     const [carClasses, setCarClasses] = useState<any[]>([]);
     const isMulticlass = false
+    const selectedCar = useSelector(selectedCarNumber)
 
     const [height, setHeight] = useState(0);
     const [width, setWidth] = useState(0);
@@ -120,8 +121,8 @@ export const TrackMap = () => {
                     }
                     if (trackMap.current != null) {
                         trackMap.current.setNodeColor(s.carNumber, classColor); /*'#f64747B3'*/
-                        // if (s.carNumber === standingsSelectedCarNumber) {
-                        //     track.current.setNodeStrokeColor(s.carNumber, '#66ff00B3');
+                        if (s.carNumber === selectedCar) {
+                            trackMap.current.setNodeStrokeColor(s.carNumber, '#FFFF00');
 
                         //     carClasses.push({
                         //         classId: -2,
@@ -153,9 +154,9 @@ export const TrackMap = () => {
                         //     track.current.setNodeColor('PIT', classColor);
                         //     track.current.setNodeStrokeColor('PIT', '#f64747B3');
                         // }
-                        // } else {
-                        trackMap.current.setNodeStrokeColor(s.carNumber, '#555555B3');
-                        //}
+                        } else {
+                            trackMap.current.setNodeStrokeColor(s.carNumber, '#555555B3');
+                        }
                     }
 
                 } else {
@@ -164,7 +165,7 @@ export const TrackMap = () => {
             });
             setCarClasses(carClasses.sort((a, b) => a.classId - b.classId))
         }
-    }, [standings, isMulticlass]);
+    }, [standings, isMulticlass, selectedCar]);
 
 
     return (

--- a/src/lib/redux/slices/authSlice/models.tsx
+++ b/src/lib/redux/slices/authSlice/models.tsx
@@ -6,10 +6,12 @@ export interface OAuthToken {
 
 export interface JwtPayload {
     sub: string,
-    name: string
+    name: string,
+    PitBoxSessionId: string,
 }
 
 export interface User {
     name: string,
-    email: string
+    email: string,
+    pitBoxSessionId: string,
 }

--- a/src/lib/redux/slices/authSlice/selectors.ts
+++ b/src/lib/redux/slices/authSlice/selectors.ts
@@ -13,8 +13,9 @@ export const selectIsAuthenticated = createSelector(
 
 export const selectUser = createSelector(
     [selectOAuthToken], (oAuthToken) => {
+        // TODO: this is a temporary fix, and need to be reworked properly
         if (oAuthToken == null) {
-            throw Error("oAuthToken null, unable to retrieve user")
+            return {} as User
         }
 
         const decoded = jwtDecode<JwtPayload>(oAuthToken.accessToken)

--- a/src/lib/redux/slices/authSlice/selectors.ts
+++ b/src/lib/redux/slices/authSlice/selectors.ts
@@ -18,7 +18,7 @@ export const selectUser = createSelector(
         }
 
         const decoded = jwtDecode<JwtPayload>(oAuthToken.accessToken)
-        const user: User = { email: decoded.sub, name: decoded.name }
+        const user: User = { email: decoded.sub, name: decoded.name, pitBoxSessionId: decoded.PitBoxSessionId}
         return user
     }
 )

--- a/src/lib/redux/slices/standingsSlice/selectors.ts
+++ b/src/lib/redux/slices/standingsSlice/selectors.ts
@@ -1,3 +1,4 @@
 import type { ReduxState } from '@/lib/redux'
 
 export const selectLiveTiming = (state: ReduxState) => state.standings.liveTiming
+export const selectedCarNumber = (state: ReduxState) => state.standings.selectedCarNumber

--- a/src/lib/redux/slices/standingsSlice/standingsSlice.ts
+++ b/src/lib/redux/slices/standingsSlice/standingsSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 
 const initialState: StandingSliceState = {
     liveTiming: [],
+    selectedCarNumber: undefined
 }
 
 export const standingsSlice = createSlice({
@@ -37,6 +38,9 @@ export const standingsSlice = createSlice({
                 }
             })
         },
+        updateSelectedCar: (state, action: PayloadAction<String | undefined>) => {
+            state.selectedCarNumber = action.payload
+        },
         reset: (state) => {
             state = initialState
         }
@@ -45,6 +49,7 @@ export const standingsSlice = createSlice({
 
 export interface StandingSliceState {
     liveTiming: LiveTiming[]
+    selectedCarNumber: String | undefined
 }
 
 export interface LiveTimingDto {
@@ -99,7 +104,3 @@ export interface LiveTiming {
     pitStopCount: number,
     stintLapCount: number,
 }
-
-
-
-


### PR DESCRIPTION
Hey @kart7990,
I now finally had the time to look into the standings table. I did some more testing and made changes to the `material-react-table` version as I wasn't able to fix the problems you also had with the refresh while having a selected row.

This PR adds the following changes:

- `Dashboard` now links to the dashboard of the logged-in user
- Store the selected car in the state and highlight the car on the track map
- Added formatting and column adjustments to the standing table

I already have some improvements in my mind like
- Have collapsible rows when it's a teams session (and show the drivers as sub rows)
- Add car brands to the table
- Change the background color for the different car classes
- Add average lap times over the last 5 / 10 laps
- ...

Let me know, if I missed something or you have additional suggestions on more info to display.

Best,
Jochen