### PR TITLE
Set eol=lf in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Make sure to have the same line-ending on different OS platforms
+* text=auto eol=lf

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "build-dev": "cross-env TARGET_ENV=development next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --check .",
+    "format": "prettier --write .",
     "prepare": "husky install",
     "postinstall": "husky install"
   },
   "lint-staged": {
-    "**/*": "prettier --check --ignore-unknown"
+    "**/*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",


### PR DESCRIPTION
Hey @kart7990,
it looks like the problem is a Windows vs Linux problem. Apparently, by default git on Windows checks out the files and converts the line endings to CRLF, while being checked out. Before committing, the line-ending gets reverted. That's also why the check fails on Windows, as it checks for the wrong line endings.

I have added a `.gitattributes` file, which sets the line-endings always to use `lf`. This should prevent the issue on another level and also from different line endings from getting into the code base.

To active this on your branch, you would need to follow the instructions described [here](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#refreshing-a-repository-after-changing-line-endings)

Best,
Jochen