### PR TITLE
add car and player details to telemetry provider

### DIFF
--- a/src/components/connection/pitwall-connection.tsx
+++ b/src/components/connection/pitwall-connection.tsx
@@ -9,7 +9,8 @@ import {
   getSelectedIRacingSessionId,
   getPitwallSession,
   getCurrentTrackSessionNumber,
-  getSelectedTelemetryProvider,
+  selectTelemetryProvider,
+  selectDataProvider,
   pitwallSlice,
   useDispatch,
   useSelector,
@@ -92,8 +93,8 @@ export default function PitwallConnection({
 
   const oAuthToken = useSelector(selectOAuthToken);
   const pitwallSession = useSelector(getPitwallSession);
-  const selectedDataProvider = useSelector(getSelectedDataProvider);
-  const selectedTelemetryProvider = useSelector(getSelectedTelemetryProvider);
+  const selectedDataProvider = useSelector(selectDataProvider);
+  const selectedTelemetryProvider = useSelector(selectTelemetryProvider);
   const selectedIRacingSessionId = useSelector(getSelectedIRacingSessionId);
   const currentTrackSessionNumber = useSelector(getCurrentTrackSessionNumber);
 
@@ -415,6 +416,17 @@ export default function PitwallConnection({
         dispatch(pitwallSlice.actions.setTelemetry(telemetry));
         telemetryDataLastResponse = Date.now();
       });
+
+      telemetryHubConnection.on(
+        "TelemetryProviderUpdate",
+        (telemetryProvider: BaseTelemetryProvider) => {
+          dispatch(
+            pitwallSlice.actions.updateTelemetryProvider(telemetryProvider),
+          );
+          telemetryDataLastResponse = Date.now();
+        },
+      );
+
       connectToTelemetry(
         pitwallSession,
         selectedTelemetryProvider,

--- a/src/components/connection/source-selection.tsx
+++ b/src/components/connection/source-selection.tsx
@@ -58,42 +58,38 @@ export function SourceSelection() {
     }
   }
 
-  function iRacingSessionIdItems() {
-    if (selectedDataProvider != null) {
-      return selectedDataProvider.gameAssignedSessionIds.map((id) => (
-        <SelectItem key={id} value={id}>
-          <div className="grid gap-2">
-            <div className="flex items-center">
-              {id}
-              <span className="ml-1 h-2 w-2 rounded-full bg-green-600"></span>
-            </div>
-          </div>
-        </SelectItem>
-      ));
-    }
-  }
+  // function iRacingSessionIdItems() {
+  //   if (selectedDataProvider != null) {
+  //     return selectedDataProvider.gameAssignedSessionIds.map((id) => (
+  //       <SelectItem key={id} value={id}>
+  //         <div className="grid gap-2">
+  //           <div className="flex items-center">
+  //             {id}
+  //             <span className="ml-1 h-2 w-2 rounded-full bg-green-600"></span>
+  //           </div>
+  //         </div>
+  //       </SelectItem>
+  //     ));
+  //   }
+  // }
 
-  function trackSessionItems() {
-    if (gameSession != null) {
-      return gameSession.trackSessions.map((trackSession) => (
-        <SelectItem
-          key={trackSession.number}
-          value={trackSession.number.toString()}
-        >
-          <div className="grid gap-2">
-            <div className="flex items-center">
-              {trackSession.number} - {trackSession.type}
-              <span className="ml-1 h-2 w-2 rounded-full bg-green-600"></span>
-            </div>
-          </div>
-        </SelectItem>
-      ));
-    }
-  }
-
-  function telemetryProviders() {
-    return <></>;
-  }
+  // function trackSessionItems() {
+  //   if (gameSession != null) {
+  //     return gameSession.trackSessions.map((trackSession) => (
+  //       <SelectItem
+  //         key={trackSession.number}
+  //         value={trackSession.number.toString()}
+  //       >
+  //         <div className="grid gap-2">
+  //           <div className="flex items-center">
+  //             {trackSession.number} - {trackSession.type}
+  //             <span className="ml-1 h-2 w-2 rounded-full bg-green-600"></span>
+  //           </div>
+  //         </div>
+  //       </SelectItem>
+  //     ));
+  //   }
+  // }
 
   return (
     <>
@@ -103,7 +99,7 @@ export function SourceSelection() {
           onValueChange={(e) => {
             dispatch(pitwallSlice.actions.changeDataProvider(e));
           }}
-          defaultValue={selectedDataProvider?.id}
+          defaultValue={selectedDataProvider}
         >
           <SelectTrigger id="data-provider">
             <SelectValue placeholder="---Select---" />
@@ -117,7 +113,7 @@ export function SourceSelection() {
           onValueChange={(e) => {
             dispatch(pitwallSlice.actions.changeTelemetryProvider(e));
           }}
-          defaultValue={selectedTelemetryProvider?.id}
+          defaultValue={selectedTelemetryProvider}
         >
           <SelectTrigger id="telemetry-provider">
             <SelectValue placeholder="---Select Driver---" />

--- a/src/lib/redux/slices/pitwallSlice/models.ts
+++ b/src/lib/redux/slices/pitwallSlice/models.ts
@@ -17,8 +17,8 @@ export interface PitwallSession {
   accessCode: string;
   creatorUserId: string;
   selectedIRacingSessionId: string;
-  selectedDataProvider: BaseGameDataProvider;
-  selectedTelemetryProvider: BaseTelemetryProvider;
+  selectedDataProvider: string;
+  selectedTelemetryProvider: string;
   gameDataProviders: BaseGameDataProvider[];
   telemetryProviders: BaseTelemetryProvider[];
   webSocketEndpoints: WebSocketEndpoints;
@@ -51,6 +51,7 @@ export interface BaseTelemetryProvider {
   carNumber: string;
   gameUserId: string;
   gameUserName: string;
+  isOnTrack: boolean;
 }
 
 export enum HubEndpoint {

--- a/src/lib/redux/slices/pitwallSlice/selectors.ts
+++ b/src/lib/redux/slices/pitwallSlice/selectors.ts
@@ -9,8 +9,14 @@ export const getPitwallSessionId = (state: ReduxState) =>
 export const getSelectedDataProvider = (state: ReduxState) =>
   state.pitwall.session?.selectedDataProvider;
 
+export const getDataProviders = (state: ReduxState) =>
+  state.pitwall.session?.gameDataProviders;
+
 export const getSelectedTelemetryProvider = (state: ReduxState) =>
   state.pitwall.session?.selectedTelemetryProvider;
+
+export const getTelemetryProviders = (state: ReduxState) =>
+  state.pitwall.session?.telemetryProviders;
 
 export const getSelectedIRacingSessionId = (state: ReduxState) =>
   state.pitwall.session?.selectedIRacingSessionId;
@@ -39,6 +45,26 @@ export const selectCurrentTrackSession = createSelector(
     if (trackSessions != null && trackSessions.length > 0) {
       return trackSessions.find(
         (ts) => ts.number === currentTrackSessionNumber,
+      );
+    }
+  },
+);
+
+export const selectDataProvider = createSelector(
+  [getSelectedDataProvider, getDataProviders],
+  (selectedDataProvider, dataProviders) => {
+    if (dataProviders != null && dataProviders.length > 0) {
+      return dataProviders.find((gdp) => gdp.id === selectedDataProvider);
+    }
+  },
+);
+
+export const selectTelemetryProvider = createSelector(
+  [getSelectedTelemetryProvider, getTelemetryProviders],
+  (selectedTelemetryProvider, telemetryProviders) => {
+    if (telemetryProviders != null && telemetryProviders.length > 0) {
+      return telemetryProviders.find(
+        (tp) => tp.id === selectedTelemetryProvider,
       );
     }
   },


### PR DESCRIPTION
Adds car number and player details to telemetry provider. Additionally, the `selectedDataProvider` and `selectedTelemetryProvider` now only contain the selected provider's id, instead of the entire provider object. I added redux selectors to get the provider objects out of the redux state.

Backend and windows app changes are required with this change. They are complete and ready to deploy once this is merged.

<img width="393" alt="Screenshot 2024-02-05 213957" src="https://github.com/kart7990/virtualpitwall/assets/15096469/a255f27a-28de-42e0-8970-b2c2b8ae8f81">
