### PR TITLE
Switch text to 'text-sm'

### DIFF
--- a/src/app/pitwall/dashboard/[id]/components/dashboard-card.tsx
+++ b/src/app/pitwall/dashboard/[id]/components/dashboard-card.tsx
@@ -14,7 +14,7 @@ export function DashboardCard({
 }) {
   return (
     <Card className="h-full overflow-hidden">
-      <CardHeader className="drag-handle border-b p-3">
+      <CardHeader className="drag-handle border-b p-2">
         <CardTitle className="m-0">{title}</CardTitle>
       </CardHeader>
       <CardContent className="h-full w-full p-0">{children}</CardContent>

--- a/src/app/pitwall/dashboard/[id]/components/dashboard-header.tsx
+++ b/src/app/pitwall/dashboard/[id]/components/dashboard-header.tsx
@@ -11,11 +11,11 @@ export function DashboardHeader({
   return (
     <>
       <div className="flow-root">
-        <div className="float-left ml-2 mt-2">
+        <div className="float-left ml-2 mt-1">
           <div className="flex space-x-6">{left}</div>
         </div>
         <div className="float-right ml-2 mt-2 space-x-6">
-          <div className="flex flex-wrap gap-4 p-3">
+          <div className="flex flex-wrap gap-4 p-2">
             {right}
             <Separator orientation="vertical" />
             <div className="mt-1">

--- a/src/app/pitwall/dashboard/[id]/components/dashboard.tsx
+++ b/src/app/pitwall/dashboard/[id]/components/dashboard.tsx
@@ -18,7 +18,6 @@ const ResponsiveGridLayout = WidthProvider(GridLayout);
 
 export default function Dashboard() {
   const session = useSelector(selectCurrentTrackSession);
-  const [sessionTitle, setSessionTitle] = useState("");
   const [carClassTitle, setCarClassTitle] = useState("");
 
   const onResizeStopped: ItemCallback = (layout, oldItem, newItem) => {
@@ -26,10 +25,10 @@ export default function Dashboard() {
   };
 
   return (
-    <main>
+    <main className="text-sm">
       <DashboardHeader
         left={<SourceSelection />}
-        right={<Session setSessionTitle={setSessionTitle} />}
+        right={<Session />}
       ></DashboardHeader>
       <ResponsiveGridLayout
         className="layout"

--- a/src/components/car-class-details/multi-class.tsx
+++ b/src/components/car-class-details/multi-class.tsx
@@ -1,15 +1,15 @@
 import {
+  getLiveTiming,
+  selectCurrentTrackSession,
+  useSelector,
+} from "@/lib/redux";
+import { LiveTiming } from "@/lib/redux/slices/pitwallSlice/models";
+import { useEffect } from "react";
+import {
   getCarClassName,
   parseIRating,
 } from "../utils/formatter/CarConversion";
 import { convertMsToDisplay } from "../utils/formatter/UnitConversion";
-import {
-  selectCurrentTrackSession,
-  useSelector,
-  getLiveTiming,
-} from "@/lib/redux";
-import { LiveTiming } from "@/lib/redux/slices/pitwallSlice/models";
-import { useEffect } from "react";
 
 interface CarClassDetails {
   id: number;
@@ -69,7 +69,7 @@ export const MultiClassDetails = ({
       {!session && <p>waiting for data</p>}
       {session && (
         <div className="overflow-auto h-full pb-10">
-          <div className="flex flex-wrap gap-4 p-3">
+          <div className="flex flex-wrap gap-4 p-2">
             {Object.entries(carClasses()).map(([classId, carClass]) => {
               return (
                 <div key={classId}>

--- a/src/components/car-class-details/single-class.tsx
+++ b/src/components/car-class-details/single-class.tsx
@@ -103,7 +103,7 @@ export const SingleClassDetails = ({
         /* Single Car Class with multiple cars */
         session && carClassValues.length > 1 && (
           <div className="overflow-auto h-full pb-10">
-            <div className="flex flex-col gap-4 p-3">
+            <div className="flex flex-col gap-4 p-2">
               <div>
                 {getSoF()}
                 <div className="font-medium">
@@ -141,7 +141,7 @@ export const SingleClassDetails = ({
         /* Single Car Class with just one car */
         session && carClassValues.length === 1 && (
           <div className="overflow-auto h-full pb-10">
-            <div className="flex flex-col p-3">
+            <div className="flex flex-col p-2">
               <span className="flex items-center uppercase text-slate-500">
                 {carClassValues[0].name}
                 <div className="justify-center items-center ml-2 mr-1">🏎️</div>

--- a/src/components/conditions/conditions.tsx
+++ b/src/components/conditions/conditions.tsx
@@ -20,7 +20,7 @@ export const Conditions = () => {
     <>
       {!conditions && <p>waiting for data</p>}
       {conditions && (
-        <div className="flex flex-wrap gap-4 p-3">
+        <div className="flex flex-wrap gap-4 p-2">
           <DataDisplay
             title="Sim Time"
             content={formatTime(trackSession?.gameDateTime)}

--- a/src/components/core/site-header.tsx
+++ b/src/components/core/site-header.tsx
@@ -1,9 +1,9 @@
-import { Button } from "./ui/button";
-import { UserNav } from "./user-nav";
 import { MainNav } from "@/components/core/main-nav";
 import { MobileNav } from "@/components/core/mobile-nav";
 import { siteConfig } from "@/config/site";
 import Link from "next/link";
+import { Button } from "./ui/button";
+import { UserNav } from "./user-nav";
 
 export function SiteHeader({ isPublic }: { isPublic: boolean }) {
   return (
@@ -18,7 +18,7 @@ export function SiteHeader({ isPublic }: { isPublic: boolean }) {
         </div>
         {!isPublic && (
           <div className="mr-4">
-            <nav className="flex gap-3">
+            <nav className="flex gap-2">
               <Link
                 href={siteConfig.links.client}
                 target="_blank"

--- a/src/components/session/session.tsx
+++ b/src/components/session/session.tsx
@@ -1,14 +1,9 @@
+import { selectCurrentTrackSession, useSelector } from "@/lib/redux";
 import { DataDisplay } from "../core/ui/data-display";
 import { LapsRemaining } from "./components/laps-remaining";
 import { TimeRemaining } from "./components/time-remaining";
-import { selectCurrentTrackSession, useSelector } from "@/lib/redux";
-import { useEffect } from "react";
 
-export const Session = ({
-  setSessionTitle,
-}: {
-  setSessionTitle: (title: string) => void;
-}) => {
+export const Session = () => {
   const session = useSelector(selectCurrentTrackSession);
 
   return (

--- a/src/components/timing/current-lap.tsx
+++ b/src/components/timing/current-lap.tsx
@@ -20,7 +20,7 @@ const Timing = () => {
       currentCar &&
       time ? (
         <>
-          <div className="flex flex-wrap gap-4 p-3">
+          <div className="flex flex-wrap gap-4 p-2">
             <DataDisplay title="Current Lap" content={time.getCurrentLap()} />
             <DataDisplay
               title="Delta Best Lap"
@@ -47,7 +47,7 @@ const Timing = () => {
           </div>
         </>
       ) : (
-        <div className="p-3">Car is not on track</div>
+        <div className="p-2">Car is not on track</div>
       )}
     </>
   );

--- a/src/components/trackmap/trackmap.tsx
+++ b/src/components/trackmap/trackmap.tsx
@@ -232,7 +232,7 @@ export const TrackMap = () => {
         />
       )}
       <div>
-        <span className="font-weight-bold flex p-3 uppercase">
+        <span className="font-weight-bold flex p-2 uppercase">
           {track?.name}
         </span>
       </div>


### PR DESCRIPTION
Hey @kart7990,
in my opinion, the text of all the components was too big. With this, I decreased the text size by one level to `text-sm`. I like this much better, but I'm happy to hear what you think.

FYI: The text size in the standings table, was already `text-sm` sized.

Best,
Jochen