### PR TITLE
Persist dashboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Virtual Pitwall platform displays all relevant iRacing event data on a web-b
 
 ### Project Frameworks
 
-Core Frameworks, and Libraries:
+Core Frameworks and Libraries:
 
 - [React](https://react.dev/)
 - [Next.js](https://nextjs.org/)

--- a/src/app/pitwall/dashboard/[id]/components/dashboard.tsx
+++ b/src/app/pitwall/dashboard/[id]/components/dashboard.tsx
@@ -18,7 +18,7 @@ import { DashboardHeader } from "./dashboard-header";
 
 const ResponsiveGridLayout = WidthProvider(GridLayout);
 
-const STORAGE_KEY: string = "dashboard_defaultLayout";
+const STORAGE_KEY: string = "dashboard_layout";
 
 class DashboardComponent {
   public id: string;
@@ -135,7 +135,6 @@ export default function Dashboard() {
     let savedLayoutJson = localStorage.getItem(STORAGE_KEY);
     if (savedLayoutJson != null) {
       let savedLayout: Layout[] = JSON.parse(savedLayoutJson);
-      console.log("savedLayout", savedLayout);
       setLayout(savedLayout);
     } else {
       setLayout(defaultLayout);

--- a/src/app/pitwall/dashboard/[id]/components/dashboard.tsx
+++ b/src/app/pitwall/dashboard/[id]/components/dashboard.tsx
@@ -11,103 +11,172 @@ import InputTelemetry from "@/components/telemetry/input-telemetry";
 import Timing from "@/components/timing/current-lap";
 import { TrackMap } from "@/components/trackmap/trackmap";
 import { selectCurrentTrackSession, useSelector } from "@/lib/redux";
-import { useState } from "react";
-import GridLayout, { ItemCallback, WidthProvider } from "react-grid-layout";
+import { useEffect, useState } from "react";
+import GridLayout, { Layout, WidthProvider } from "react-grid-layout";
 import { DashboardCard } from "./dashboard-card";
 import { DashboardHeader } from "./dashboard-header";
 
 const ResponsiveGridLayout = WidthProvider(GridLayout);
 
+const STORAGE_KEY: string = "dashboard_defaultLayout";
+
+class DashboardComponent {
+  public id: string;
+  public content: React.ReactNode;
+  public title: string;
+  public description: string;
+
+  constructor(
+    id: string,
+    title: string,
+    description: string,
+    content: React.ReactNode,
+  ) {
+    this.id = id;
+    this.title = title;
+    this.description = description;
+    this.content = content;
+  }
+}
+
 export default function Dashboard() {
   const session = useSelector(selectCurrentTrackSession);
   const [carClassTitle, setCarClassTitle] = useState("");
+  const [layout, setLayout] = useState<Layout[]>();
 
-  const onResizeStopped: ItemCallback = (layout, oldItem, newItem) => {
-    console.log("Grid-RESIZE", newItem.i);
+  const defaultLayout: Layout[] = [
+    { i: "carClassDetails", x: 0, y: 2, w: 4, h: 2, minH: 1 },
+    { i: "trackMap", x: 0, y: 4, w: 4, h: 2, minH: 2 },
+    { i: "standings", x: 4, y: 2, w: 8, h: 8, minH: 2 },
+    { i: "currentLap", x: 0, y: 8, w: 4, h: 1 },
+    { i: "carTelemetry", x: 0, y: 9, w: 4, h: 1 },
+    { i: "inputTelemetry", x: 0, y: 9, w: 4, h: 1 },
+    { i: "fuelAnalysis", x: 0, y: 11, w: 4, h: 3 },
+  ];
+
+  let components: DashboardComponent[] = [
+    new DashboardComponent(
+      "carClassDetails",
+      "Class Details",
+      "Displays session details about each car and car classes.",
+      (
+        <DashboardCard title={carClassTitle}>
+          {session?.isMulticlass ? (
+            <MultiClassDetails setCarClassTitle={setCarClassTitle} />
+          ) : (
+            <SingleClassDetails setCarClassTitle={setCarClassTitle} />
+          )}
+        </DashboardCard>
+      ),
+    ),
+    new DashboardComponent(
+      "trackMap",
+      "Track Map",
+      "Displays an interactive track map.",
+      (
+        <DashboardCard title="Track Map">
+          <TrackMap />
+        </DashboardCard>
+      ),
+    ),
+    new DashboardComponent(
+      "standings",
+      "Standings",
+      "Displays live timing and standings.",
+      (
+        <DashboardCard title="Standings">
+          <Standings />
+        </DashboardCard>
+      ),
+    ),
+    new DashboardComponent(
+      "currentLap",
+      "Current Lap Details",
+      "Displays details about the current lap.",
+      (
+        <DashboardCard title="Current Lap">
+          <Timing />
+        </DashboardCard>
+      ),
+    ),
+    new DashboardComponent(
+      "carTelemetry",
+      "Car Telemetry",
+      "Displays car telemetry.",
+      (
+        <DashboardCard title="Car Telemetry">
+          <Telemetry />
+        </DashboardCard>
+      ),
+    ),
+    new DashboardComponent(
+      "inputTelemetry",
+      "Input Telemetry",
+      "Displays input telemetry.",
+      (
+        <DashboardCard title="Input Telemetry">
+          <InputTelemetry />
+        </DashboardCard>
+      ),
+    ),
+    new DashboardComponent(
+      "fuelAnalysis",
+      "Fuel Analysis",
+      "Displays fuel analysis.",
+      (
+        <DashboardCard title="Fuel Analysis">
+          <FuelAnalysis />
+        </DashboardCard>
+      ),
+    ),
+  ];
+
+  useEffect(() => {
+    let savedLayoutJson = localStorage.getItem(STORAGE_KEY);
+    if (savedLayoutJson != null) {
+      let savedLayout: Layout[] = JSON.parse(savedLayoutJson);
+      console.log("savedLayout", savedLayout);
+      setLayout(savedLayout);
+    } else {
+      setLayout(defaultLayout);
+    }
+  }, []);
+
+  function renderComponents() {
+    return layout?.map((layoutItem) => (
+      <div
+        key={layoutItem.i}
+        data-grid={layoutItem}
+        className="overflow-hidden"
+      >
+        {components.find((c) => c.id === layoutItem.i)?.content}
+      </div>
+    ));
+  }
+
+  const onLayoutChange = (layout: Layout[]) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(layout));
   };
 
   return (
-    <main className="text-sm">
-      <DashboardHeader
-        left={<SourceSelection />}
-        right={<Session />}
-      ></DashboardHeader>
-      <ResponsiveGridLayout
-        className="layout"
-        isDraggable={true}
-        isResizable={true}
-        draggableHandle=".drag-handle"
-        onResizeStop={onResizeStopped}
-        resizeHandles={["se"]}
-      >
-        <div
-          key="carClasses"
-          className="overflow-hidden"
-          data-grid={{ x: 0, y: 2, w: 4, h: 2, minH: 1 }}
+    <>
+      {console.log("render", layout)}
+      <main className="text-sm">
+        <DashboardHeader
+          left={<SourceSelection />}
+          right={<Session />}
+        ></DashboardHeader>
+        <ResponsiveGridLayout
+          className="layout"
+          isDraggable={true}
+          isResizable={true}
+          draggableHandle=".drag-handle"
+          onLayoutChange={onLayoutChange}
+          resizeHandles={["se"]}
         >
-          <DashboardCard title={carClassTitle}>
-            {session?.isMulticlass ? (
-              <MultiClassDetails setCarClassTitle={setCarClassTitle} />
-            ) : (
-              <SingleClassDetails setCarClassTitle={setCarClassTitle} />
-            )}
-          </DashboardCard>
-        </div>
-        <div
-          key="trackMap"
-          className="overflow-hidden"
-          data-grid={{ x: 0, y: 4, w: 4, h: 2, minH: 2 }}
-        >
-          <DashboardCard title="Track Map">
-            <TrackMap />
-          </DashboardCard>
-        </div>
-        <div
-          key="standings"
-          className="overflow-hidden"
-          data-grid={{ x: 4, y: 2, w: 8, h: 8, minH: 2 }}
-        >
-          <DashboardCard title="Standings">
-            <Standings />
-          </DashboardCard>
-        </div>
-        <div
-          key="currentLap"
-          className="overflow-hidden"
-          data-grid={{ x: 0, y: 8, w: 4, h: 1 }}
-        >
-          <DashboardCard title="Current Lap">
-            <Timing />
-          </DashboardCard>
-        </div>
-        <div
-          key="cartTelemetry"
-          className="overflow-hidden"
-          data-grid={{ x: 0, y: 9, w: 4, h: 1 }}
-        >
-          <DashboardCard title="Car Telemetry">
-            <Telemetry />
-          </DashboardCard>
-        </div>
-        <div
-          key="inputTelemetry"
-          className="overflow-hidden"
-          data-grid={{ x: 0, y: 9, w: 4, h: 1 }}
-        >
-          <DashboardCard title="Input Telemetry">
-            <InputTelemetry />
-          </DashboardCard>
-        </div>
-        <div
-          key="fuelAnalysis"
-          className="overflow-hidden"
-          data-grid={{ x: 0, y: 11, w: 4, h: 3 }}
-        >
-          <DashboardCard title="Fuel Analysis">
-            <FuelAnalysis />
-          </DashboardCard>
-        </div>
-      </ResponsiveGridLayout>
-    </main>
+          {renderComponents()}
+        </ResponsiveGridLayout>
+      </main>
+    </>
   );
 }

--- a/src/components/car-class-details/multi-class.tsx
+++ b/src/components/car-class-details/multi-class.tsx
@@ -1,6 +1,6 @@
 import {
-  getLiveTiming,
   selectCurrentTrackSession,
+  selectLiveTiming,
   useSelector,
 } from "@/lib/redux";
 import { LiveTiming } from "@/lib/redux/slices/pitwallSlice/models";
@@ -27,7 +27,7 @@ export const MultiClassDetails = ({
   setCarClassTitle: (title: string) => void;
 }) => {
   const session = useSelector(selectCurrentTrackSession);
-  const standings = useSelector<LiveTiming[]>(getLiveTiming);
+  const standings = useSelector<LiveTiming[]>(selectLiveTiming);
 
   useEffect(() => {
     setCarClassTitle("Multi-Class Details");

--- a/src/components/car-class-details/single-class.tsx
+++ b/src/components/car-class-details/single-class.tsx
@@ -1,6 +1,6 @@
 import {
-  getLiveTiming,
   selectCurrentTrackSession,
+  selectLiveTiming,
   useSelector,
 } from "@/lib/redux";
 import { LiveTiming } from "@/lib/redux/slices/pitwallSlice/models";
@@ -23,7 +23,7 @@ export const SingleClassDetails = ({
   setCarClassTitle: (title: string) => void;
 }) => {
   const session = useSelector(selectCurrentTrackSession);
-  const standings = useSelector<LiveTiming[]>(getLiveTiming);
+  const standings = useSelector<LiveTiming[]>(selectLiveTiming);
 
   const totalIRating = standings.reduce(
     (sum, current) => sum + current.iRating,

--- a/src/components/core/settings.tsx
+++ b/src/components/core/settings.tsx
@@ -29,7 +29,6 @@ export function Settings() {
   const dispatch = useDispatch();
   const selectedMeasurementSystem = useSelector(selectMeasurementSystem);
 
-  console.log(selectedMeasurementSystem.measurement.toString());
   return (
     <Sheet>
       <SheetTrigger asChild>

--- a/src/components/session/components/laps-remaining.tsx
+++ b/src/components/session/components/laps-remaining.tsx
@@ -1,13 +1,13 @@
 import { DataDisplay } from "@/components/core/ui/data-display";
 import {
   selectCurrentTrackSession,
-  getLiveTiming,
+  selectLiveTiming,
   useSelector,
 } from "@/lib/redux";
 import { TrackSession } from "@/lib/redux/slices/pitwallSlice/models";
 
 export const LapsRemaining = () => {
-  const timing = useSelector(getLiveTiming);
+  const timing = useSelector(selectLiveTiming);
   const session: TrackSession | undefined = useSelector(
     selectCurrentTrackSession,
   );

--- a/src/components/standings/standings.tsx
+++ b/src/components/standings/standings.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import {
-  getLiveTiming,
   pitwallSlice,
   selectCurrentTrackSession,
+  selectLiveTiming,
   useDispatch,
   useSelector,
 } from "@/lib/redux";
@@ -24,7 +24,7 @@ export const Standings = () => {
   const dispatch = useDispatch();
 
   const [data, setData] = useState<LiveTiming[]>([]);
-  const standingsData = useSelector<LiveTiming[]>(getLiveTiming);
+  const standingsData = useSelector<LiveTiming[]>(selectLiveTiming);
   const [rowSelection, setRowSelection] = useState<MRT_RowSelectionState>({});
   const session = useSelector(selectCurrentTrackSession);
 

--- a/src/components/trackmap/trackmap.tsx
+++ b/src/components/trackmap/trackmap.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import {
-  getLiveTiming,
   getSelectedCar,
   selectCurrentTrack,
+  selectLiveTiming,
   useSelector,
 } from "@/lib/redux";
 import { LiveTiming } from "@/lib/redux/slices/pitwallSlice/models";
@@ -19,7 +19,7 @@ export const TrackMap = () => {
   const [rivalTrackerPathsJsLoaded, setRivalTrackerPathsJsLoaded] =
     useState(false);
   const [allJsLoaded, setAllJsLoaded] = useState(false);
-  const standings: LiveTiming[] = useSelector(getLiveTiming);
+  const standings: LiveTiming[] = useSelector(selectLiveTiming);
   const track = useSelector(selectCurrentTrack);
   const [carClasses, setCarClasses] = useState<any[]>([]);
   const isMulticlass = false;

--- a/src/lib/redux/slices/preferencesSlice/selectors.ts
+++ b/src/lib/redux/slices/preferencesSlice/selectors.ts
@@ -1,5 +1,13 @@
 import type { ReduxState } from "@/lib/redux";
-import { Measurement } from "./models";
+import { createSelector } from "@reduxjs/toolkit";
+import { Measurement, MeasurementSystem } from "./models";
 
-export const selectMeasurementSystem = (state: ReduxState) =>
-  new Measurement(state.preferences.measurementSystem);
+export const getMeasurementSystem = (state: ReduxState) =>
+  state.preferences.measurementSystem;
+
+export const selectMeasurementSystem = createSelector(
+  [getMeasurementSystem],
+  (measurementSystem: MeasurementSystem) => {
+    return new Measurement(measurementSystem);
+  },
+);


### PR DESCRIPTION
This change adds dashboard layout persistence. The layout will be saved to local storage automatically anytime an item is resized or moved. It also fixes redux selector memoization issues to help improve performance.

I will follow up with another PR shortly to add the ability to add and remove components from the dashboard.